### PR TITLE
Strictly check NodeList abilities for selectorToArr

### DIFF
--- a/src/Slim.js
+++ b/src/Slim.js
@@ -980,7 +980,7 @@ catch (err) {
     Slim.__isIE11 = false;
 }
 
-if (Slim.__isWCSupported) {
+if (Slim.__isWCSupported && NodeList.prototype.hasOwnProperty('forEach')) {
     Slim.selectorToArr = function(target, selector) {
         return target.querySelectorAll(selector);
     }


### PR DESCRIPTION
Some browsers may have `__isWCSupported` true but can not use array-like `forEach` in the result of `querySelectorAll()` (which is a `NodeList` instance)