### PR TITLE
Correct version number of web components spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ But... wait! there's more:
 
 ## Standards compilant
 - es6
-- web-components V2
+- web-components V1
 - no transpiling or compilation required
 
 ## Tools free


### PR DESCRIPTION
V0 was the initial implementation. The second iteration is thus webcomponents v1 instead of v2 😄 