### PR TITLE
warn in case of multiple includes of the lib Slim.js

### DIFF
--- a/src/Slim.js
+++ b/src/Slim.js
@@ -92,9 +92,8 @@
       }
       this.tagToClassDict.set(tagName, clazz)
       this.classToTagDict.set(clazz, tagName)
-      var alreadyDefined = customElements.get(tagName)
-      if(alreadyDefined){
-        console.warn("Tag name: "+tagName+" is already defined!, maybe Slim.js was included multiple times");
+      if(customElements.get(tagName)){
+        throw new Error(`Tag name: ${tagName} is already defined!, maybe Slim.js was included multiple times`)
       }else{
         customElements.define(tagName, clazz)
       }

--- a/src/Slim.js
+++ b/src/Slim.js
@@ -92,7 +92,12 @@
       }
       this.tagToClassDict.set(tagName, clazz)
       this.classToTagDict.set(clazz, tagName)
-      customElements.define(tagName, clazz)
+      var alreadyDefined = customElements.get(tagName)
+      if(alreadyDefined){
+        console.warn("Tag name: "+tagName+" is already defined!, maybe Slim.js was included multiple times");
+      }else{
+        customElements.define(tagName, clazz)
+      }
     }
 
     static tagOf (clazz) {


### PR DESCRIPTION
In case of multiple includes of the lib (something that happened from time to time), the lib throws errors that are not relevant to the issue, maybe it's a good idea to warn about it.