### PR TITLE
[package] Set 'default' as last keys on exports entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
       "default": "./dist/directives/attribute.directive.js"
     },
     "./event-directive": {
-      "default": "./dist/directives/event.directive.js",
-      "require": "./dist/directives/event.directive.js"
+      "require": "./dist/directives/event.directive.js",
+      "default": "./dist/directives/event.directive.js"
     },
     "./if-directive": {
       "require": "./dist/directives/if.directive.js",


### PR DESCRIPTION
This is necessary because of webpack specs: https://webpack.js.org/guides/package-exports/#conditional-syntax

This fix the build with a webpack v5 project using slim.js